### PR TITLE
Handle FINE_GRAIN_GROUP_LOG callsites with a dynamic `NAME`

### DIFF
--- a/source/common/common/fine_grain_logger.cc
+++ b/source/common/common/fine_grain_logger.cc
@@ -7,6 +7,7 @@
 
 #include "source/common/common/logger.h"
 
+#include "absl/strings/match.h"
 #include "absl/strings/str_join.h"
 
 using spdlog::level::level_enum;
@@ -48,6 +49,26 @@ SpdLoggerSharedPtr FineGrainLogContext::getFineGrainLogEntryForFlush(absl::strin
 spdlog::level::level_enum FineGrainLogContext::getVerbosityDefaultLevel() const {
   absl::ReaderMutexLock l(fine_grain_log_lock_);
   return verbosity_default_level_;
+}
+
+bool FineGrainLogContext::checkFineGrainLogger(spdlog::logger* logger, absl::string_view file,
+                                             absl::string_view name) {
+  absl::string_view logger_name = logger->name();
+  // Fast path for static strings: the pointer address might match if they are string literals.
+  // spdlog logger name is usually a std::string, so logger_name.data() is not the same as file.data().
+  
+  if (name.empty()) {
+    return logger_name == file;
+  }
+
+  // Common case: logger_name was created as absl::StrCat(file, ":", name)
+  if (logger_name.size() != file.size() + 1 + name.size()) {
+    return false;
+  }
+
+  const char* d = logger_name.data();
+  return d[file.size()] == ':' && absl::StartsWith(logger_name, file) &&
+         absl::EndsWith(logger_name, name);
 }
 
 spdlog::logger* FineGrainLogContext::initFineGrainLogger(absl::string_view file,

--- a/source/common/common/fine_grain_logger.h
+++ b/source/common/common/fine_grain_logger.h
@@ -145,6 +145,12 @@ public:
   static bool safeFileNameMatch(absl::string_view pattern, absl::string_view str);
 
   /**
+   * Check if a logger's name matches the given file and logger name.
+   */
+  bool checkFineGrainLogger(spdlog::logger* logger, absl::string_view file, absl::string_view name)
+      ABSL_LOCKS_EXCLUDED(fine_grain_log_lock_);
+
+  /**
    * Remove a fine grain log entry for testing only.
    */
   void removeFineGrainLogEntryForTest(absl::string_view key)
@@ -220,15 +226,16 @@ FineGrainLogContext& getFineGrainLogContext();
  * spdlog::logger* as atomic<shared_ptr> is a C++20 feature.
  */
 #define FINE_GRAIN_LOGGER(NAME)                                                                    \
-  ([&]() -> spdlog::logger* {                                                                      \
+  ([&](absl::string_view name) -> spdlog::logger* {                                                \
     static std::atomic<spdlog::logger*> flogger{nullptr};                                          \
     spdlog::logger* local_flogger = flogger.load(std::memory_order_acquire);                       \
-    if (!local_flogger) {                                                                          \
+    if (!local_flogger ||                                                                          \
+        !::Envoy::getFineGrainLogContext().checkFineGrainLogger(local_flogger, __FILE__, name)) {  \
       local_flogger =                                                                              \
-          ::Envoy::getFineGrainLogContext().initFineGrainLogger(__FILE__, NAME, flogger);          \
+          ::Envoy::getFineGrainLogContext().initFineGrainLogger(__FILE__, name, flogger);          \
     }                                                                                              \
     return local_flogger;                                                                          \
-  }())
+  }(NAME))
 
 /**
  * Macro for fine-grain logger to log without a group.

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -11,6 +11,16 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
+envoy_cc_benchmark_binary(
+    name = "fine_grain_logger_benchmark",
+    srcs = ["fine_grain_logger_benchmark.cc"],
+    rbe_pool = "6gig",
+    deps = [
+        "//source/common/common:minimal_logger_lib",
+        "@benchmark",
+    ],
+)
+
 envoy_cc_test(
     name = "backoff_strategy_test",
     srcs = ["backoff_strategy_test.cc"],

--- a/test/common/common/fine_grain_logger_benchmark.cc
+++ b/test/common/common/fine_grain_logger_benchmark.cc
@@ -1,0 +1,107 @@
+#include <string>
+
+#include "source/common/common/fine_grain_logger.h"
+#include "source/common/common/logger.h"
+
+#include "benchmark/benchmark.h"
+
+namespace Envoy {
+
+// Mocking the behavior of the OLD macro (no check)
+#define OLD_FINE_GRAIN_LOGGER(NAME, FLOGGER_VAR)                                                   \
+  ([&]() -> spdlog::logger* {                                                                      \
+    spdlog::logger* local_flogger = FLOGGER_VAR.load(std::memory_order_acquire);                   \
+    if (!local_flogger) {                                                                          \
+      local_flogger =                                                                              \
+          ::Envoy::getFineGrainLogContext().initFineGrainLogger(__FILE__, NAME, FLOGGER_VAR);      \
+    }                                                                                              \
+    return local_flogger;                                                                          \
+  }())
+
+/**
+ * Benchmark for the FIXED FINE_GRAIN_LOGGER macro with a STATIC name.
+ * This measures the overhead of checkFineGrainLogger when it succeeds.
+ */
+static void BM_FineGrainStaticFixed(benchmark::State& state) {
+  spdlog::level::level_enum lv = state.range(0) ? spdlog::level::trace : spdlog::level::info;
+  getFineGrainLogContext().setFineGrainLogger(__FILE__, lv);
+  // Disable logging to avoid I/O overhead in benchmark
+  auto logger = getFineGrainLogContext().getFineGrainLogEntry(__FILE__);
+  if (logger) {
+    logger->set_level(spdlog::level::off);
+  }
+  for (auto _ : state) {
+    // This uses the NEW macro (with the fix)
+    FINE_GRAIN_LOG(trace, "Static message");
+  }
+}
+
+/**
+ * Benchmark for the OLD FINE_GRAIN_LOGGER macro with a STATIC name.
+ * This represents the baseline performance before the fix.
+ */
+static void BM_FineGrainStaticOld(benchmark::State& state) {
+  spdlog::level::level_enum lv = state.range(0) ? spdlog::level::trace : spdlog::level::info;
+  getFineGrainLogContext().setFineGrainLogger(__FILE__, lv);
+  static std::atomic<spdlog::logger*> old_flogger{nullptr};
+  // Ensure the logger exists and disable logging to avoid I/O overhead
+  OLD_FINE_GRAIN_LOGGER("", old_flogger); 
+  auto logger = getFineGrainLogContext().getFineGrainLogEntry(__FILE__);
+  if (logger) {
+    logger->set_level(spdlog::level::off);
+  }
+  for (auto _ : state) {
+    spdlog::logger* local_flogger = OLD_FINE_GRAIN_LOGGER("", old_flogger);
+    if (ENVOY_LOG_COMP_LEVEL(*local_flogger, trace)) {
+       local_flogger->log(spdlog::source_loc{__FILE__, __LINE__, __func__}, spdlog::level::trace, "Static message");
+    }
+  }
+}
+
+/**
+ * Benchmark for the FIXED FINE_GRAIN_LOGGER macro with a DYNAMIC name.
+ * This measures the cost of switching loggers (correct behavior).
+ */
+static void BM_FineGrainDynamicFixed(benchmark::State& state) {
+  spdlog::level::level_enum lv = state.range(0) ? spdlog::level::trace : spdlog::level::info;
+  const std::string name1 = "name1";
+  const std::string name2 = "name2";
+  const std::string key1 = absl::StrCat(__FILE__, ":", name1);
+  const std::string key2 = absl::StrCat(__FILE__, ":", name2);
+  getFineGrainLogContext().setFineGrainLogger(key1, lv);
+  getFineGrainLogContext().setFineGrainLogger(key2, lv);
+  
+  // Ensure loggers exist and disable logging to avoid I/O overhead
+  auto logger1 = getFineGrainLogContext().getFineGrainLogEntry(key1);
+  if (logger1) logger1->set_level(spdlog::level::off);
+  auto logger2 = getFineGrainLogContext().getFineGrainLogEntry(key2);
+  if (logger2) logger2->set_level(spdlog::level::off);
+
+  bool toggle = false;
+  for (auto _ : state) {
+    const std::string& name = toggle ? name1 : name2;
+    FINE_GRAIN_GROUP_LOG(trace, name, "Dynamic message");
+    toggle = !toggle;
+  }
+}
+
+/**
+ * Benchmark for standard ENVOY_LOG_MISC (for comparison).
+ */
+static void BM_EnvoyLogMisc(benchmark::State& state) {
+  spdlog::level::level_enum lv = state.range(0) ? spdlog::level::trace : spdlog::level::info;
+  GET_MISC_LOGGER().set_level(lv);
+  // Disable logging to avoid I/O overhead in benchmark
+  GET_MISC_LOGGER().set_level(spdlog::level::off);
+  for (auto _ : state) {
+    ENVOY_LOG_MISC(trace, "Static message");
+  }
+}
+
+// Range(0) = 0 means log level is INFO (trace log suppressed), 1 means log level is TRACE (log emitted).
+BENCHMARK(BM_FineGrainStaticOld)->Args({0})->Args({1});
+BENCHMARK(BM_FineGrainStaticFixed)->Args({0})->Args({1});
+BENCHMARK(BM_FineGrainDynamicFixed)->Args({0})->Args({1});
+BENCHMARK(BM_EnvoyLogMisc)->Args({0})->Args({1});
+
+} // namespace Envoy

--- a/test/common/common/log_macros_test.cc
+++ b/test/common/common/log_macros_test.cc
@@ -513,4 +513,46 @@ TEST(FineGrainLog, envoyFlushLogMacro) {
   loggable.doFlush();
 }
 
+namespace {
+// Helper function that uses ENVOY_LOG_TO_LOGGER.
+// In a real application, this might be a method in a base class or a shared utility.
+void sharedLogHelper(spdlog::logger& logger, absl::string_view message) {
+  ENVOY_LOG_TO_LOGGER(logger, info, "{}", message);
+}
+} // namespace
+
+TEST(FineGrainLog, CachingCorrectnessWithDynamicNames) {
+  Envoy::Thread::MutexBasicLockable lock;
+  // Initialize logging context with fine-grain logging enabled.
+  // Use a custom format that includes the logger name (%n) so we can verify it.
+  Logger::Context logging_context{spdlog::level::info, "[%n] %v", lock, false, true};
+
+  // We will use two different standard loggers.
+  spdlog::logger& admin_logger = Logger::Registry::getLog(Logger::Id::admin);
+  spdlog::logger& upstream_logger = Logger::Registry::getLog(Logger::Id::upstream);
+
+  // Define the keys that Fine-Grain logger will use.
+  const std::string admin_key = absl::StrCat(__FILE__, ":admin");
+  const std::string upstream_key = absl::StrCat(__FILE__, ":upstream");
+
+  // Ensure we start with a clean state for this file's loggers.
+  getFineGrainLogContext().removeFineGrainLogEntryForTest(admin_key);
+  getFineGrainLogContext().removeFineGrainLogEntryForTest(upstream_key);
+
+  // 1. Call the helper with the admin logger.
+  // This will initialize the static 'flogger' in sharedLogHelper with the admin fine-grain logger.
+  EXPECT_LOG_CONTAINS("", absl::StrCat("[", admin_key, "] message 1"),
+                      sharedLogHelper(admin_logger, "message 1"));
+
+  // 2. Call the helper with the upstream logger.
+  // With the fix, the static 'flogger' will be updated because checkFineGrainLogger will fail.
+  EXPECT_LOG_CONTAINS("", absl::StrCat("[", upstream_key, "] message 2"),
+                      sharedLogHelper(upstream_logger, "message 2"));
+
+  // 3. Call the helper with the admin logger again.
+  // It should correctly switch back to admin.
+  EXPECT_LOG_CONTAINS("", absl::StrCat("[", admin_key, "] message 3"),
+                      sharedLogHelper(admin_logger, "message 3"));
+}
+
 } // namespace Envoy


### PR DESCRIPTION
bazel run -c opt //test/common/common:fine_grain_logger_benchmark

---------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations
---------------------------------------------------------------------
BM_FineGrainStaticOld/0         0.636 ns        0.636 ns   1098812176
BM_FineGrainStaticOld/1         0.629 ns        0.629 ns   1121866499
BM_FineGrainStaticFixed/0        7.91 ns         7.91 ns     83108698
BM_FineGrainStaticFixed/1        7.85 ns         7.84 ns     86692038
BM_FineGrainDynamicFixed/0       63.0 ns         63.0 ns     10738450
BM_FineGrainDynamicFixed/1       63.0 ns         63.0 ns     11014320
BM_EnvoyLogMisc/0                5.03 ns         5.02 ns    132012972
BM_EnvoyLogMisc/1                5.05 ns         5.04 ns    132605438